### PR TITLE
Fix arg destructuring in reg-fx for :kee-frame.websocket/open

### DIFF
--- a/src/kee_frame/websocket.cljs
+++ b/src/kee_frame/websocket.cljs
@@ -77,8 +77,8 @@
                                                  :state       :connected})})))
 
 (rf/reg-fx ::open
-           (fn [_ {:keys [path format]
-                   :as   socket-config}]
+           (fn [{:keys [path format]
+                 :as   socket-config}]
              (go
               (let [url (websocket-url path)
                     {:keys [ws-channel error]} (<! (chord/ws-ch url {:format format}))]


### PR DESCRIPTION
I was getting an error that the `path` string was nil, and I think this destructuring is what caused it. Easy fix, though : )